### PR TITLE
added a workflow to version and publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,45 @@
+name: Publish Module
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of release. patch or minor (major if breaking)'
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+
+jobs:
+  publish-module:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version}}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install dependencies
+      run: npm ci
+    - name: Version ${{ github.event.inputs.release_type }} 
+      run: npm version ${{ github.event.inputs.release_type }} 
+    - name: Setup GitHub Credentials
+      run: |
+        git config user.name $GITHUB_ACTOR
+        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+    - name: Publish module
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Push changes and tags 
+      run: git push --tags
+


### PR DESCRIPTION
This PR adds a workflow to create a new version and subsequently publish `@newrelic/security-agent`.  The options are the semantic versioning types of patch, minor, major.  

Please be cognizant of the changes that are going into a release and picking the semver type accordingly.   Use [semantic versioning](https://semver.org/) as a resource.  

This is not intended to be used until the first version v0.0.1 is publish manually by myself.  I'm still waiting on approval from @coreyarnold and @k2jayant to do that effort.  We have added your NPM_TOKEN to the settings of this repo.  

**NOTE**: This has been untested to a degree in here.  When you use this to publish your next release please ping me so I can inspect things to make sure all is well.