### PR TITLE
Fixed npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,12 +30,12 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install dependencies
       run: npm ci
-    - name: Version ${{ github.event.inputs.release_type }} 
-      run: npm version ${{ github.event.inputs.release_type }} 
     - name: Setup GitHub Credentials
       run: |
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+    - name: Version ${{ github.event.inputs.release_type }} 
+      run: npm version ${{ github.event.inputs.release_type }} 
     - name: Publish module
       run: npm publish
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/security-agent",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/security-agent",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "description": "Newrelic Security Agent for Node.js",
   "main": "index.js",
   "collectorVersion": "1.0.1-limited-preview",


### PR DESCRIPTION
I was setting git config after running npm version.  Since npm version commits a tag the git config needs to be before.

@sumitsuthar this workflow both versions package based on the semver release type you choose(patch, minor, major) and then also publishes and pushes tags.  What that means is you should never have to manually edit package.json/package-lock.json with a new version this workflow will handle it.  