### PR TITLE
fix: updated npm-publish workflow to use `--follow-tags` which will push the branch and tags made

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,5 +41,5 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Push changes and tags 
-      run: git push --tags
+      run: git push --follow-tags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@newrelic/security-agent",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@newrelic/security-agent",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-lambda": "3.276.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/security-agent",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Newrelic Security Agent for Node.js",
   "main": "index.js",
   "collectorVersion": "1.0.1-limited-preview",


### PR DESCRIPTION
I noticed that the package.json and package-lock.json was out of sync. This is because the release workflow was only pushing tags not the changes made when it runs npm version. This will fix this and get package.json and package-lock.json in sync.
