### PR TITLE
chore: updated repolinter config to use community-plus rulesets

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -27,5 +27,5 @@ jobs:
         if: ${{ steps.default-branch.outputs.result == 'true' }}
         uses: newrelic/repolinter-action@v1
         with:
-          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-project.yml
+          config_url: https://raw.githubusercontent.com/newrelic/.github/main/repolinter-rulesets/community-plus.yml
           output_type: issue


### PR DESCRIPTION
I noticed the repolinter is failing for 2 reasons.  One I cannot resolve as there needs to be some discuss topic in the forum but that's probably not necessary until GA. But the configuration was set for community not community plus, so I fixed that in this PR.
