### PR TITLE
ci: updated workflows to version and publish in separate workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,21 +2,13 @@ name: Publish Module
 
 on:
   workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Type of release. patch or minor (major if breaking)'
-        required: true
-        type: choice
-        default: patch
-        options:
-          - patch
-          - minor
-          - major
-
 
 jobs:
   publish-module:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     strategy:
       matrix:
         node-version: [lts/*]
@@ -34,12 +26,14 @@ jobs:
       run: |
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-    - name: Version ${{ github.event.inputs.release_type }} 
-      run: npm version ${{ github.event.inputs.release_type }} 
     - name: Publish module
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - name: Push changes and tags 
-      run: git push --follow-tags
+    - name: Create and push tag 
+      run: |
+        VERSION=`node -e "const { version } = require('./package.json'); console.log(version);"`
+        git tag v$VERSION
+        git push --tags
+
 

--- a/.github/workflows/version-pkg.yml
+++ b/.github/workflows/version-pkg.yml
@@ -1,0 +1,50 @@
+name: Version Module
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of release. patch or minor (major if breaking)'
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+
+jobs:
+  version-module:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version}}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - name: Setup GitHub Credentials
+      run: |
+        git config user.name $GITHUB_ACTOR
+        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+    - name: Version ${{ github.event.inputs.release_type }} 
+      run: npm version ${{ github.event.inputs.release_type }} 
+    - name: Get new package version
+      run: echo "VERSION=`node -e \"const { version } = require('./package.json'); console.log(version);\"`" >> $GITHUB_ENV
+    - name: Create release branch
+      run: |
+        git checkout -b release/v$VERSION
+        git push --set-upstream origin release/v$VERSION
+    - name: Create PR
+      run: gh pr create -B main --title "Release v$VERSION" --body "Automated release of v$VERSION"
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR splits out versioning and publishing.  

The new workflow will be as follows:
 * Run the Version Module workflow and pick the appropriate semver type.
     * It will version the package
     * Open PR with the package.json and package-lock changes
     * Someone must review and merge PR
 * Run the Publish module workflow
     * This will publish the package
     * Create a tag with the appropriate version and push tag to tip of main


You can see I tested this in my fork(commented out the publish) and all worked well: https://github.com/bizob2828/csec-node-agent/pull/4