### PR TITLE
fix(mysql): fixed getConnection instrumentation to check if callback is wrapped or the "original" callback to avoid infinite wrapping

### DIFF
--- a/lib/instrumentation-security/hooks/mysql/nr-mysql.js
+++ b/lib/instrumentation-security/hooks/mysql/nr-mysql.js
@@ -5,13 +5,20 @@
 
 const requestManager = require("../../core/request-manager");
 
-const async_hooks = require("async_hooks");
 const secUtils = require('../../core/sec-utils');
 const API = require("../../../nr-security-api");
 const securityMetaData = require('../../core/security-metadata');
 const { EVENT_TYPE, EVENT_CATEGORY } = require('../../core/event-constants');
 const { NR_CSEC_FUZZ_REQUEST_ID } = require('../../core/constants');
 const logger = API.getLogger();
+const symbols = {
+  unwrapConnection: Symbol('unwrapConnection'),
+  unwrapPool: Symbol('unwrapPool'),
+  clusterOf: Symbol('clusterOf'),
+  createPoolCluster: Symbol('createPoolCluster'),
+  wrappedPoolConnection: Symbol('wrappedPoolConnection')
+
+}
 
 module.exports = initialize;
 
@@ -34,37 +41,53 @@ function initialize(shim, mysql, moduleName) {
  * Wrapper for mysql module hooks
  * @param {*} shim 
  * @param {*} mysql 
- * @param {*} moduleName 
  */
-function callbackInitialize(shim, mysql, moduleName) {
-  shim.__wrappedPoolConnection = false;
+function callbackInitialize(shim, mysql) {
+  shim[symbols.wrappedPoolConnection] = true
 
   shim.wrapReturn(mysql, "createConnection", wrapCreateConnection);
   function wrapCreateConnection(shim, fn, fnName, connection) {
+    if (shim[symbols.unwrapConnection]) {
+      return
+    }
+
     if (wrapQueryable(shim, connection, false)) {
       const connProto = Object.getPrototypeOf(connection);
-      shim.unwrap(mysql, "createConnection");
+      shim[symbols.unwrapConnection] = true
     }
   }
 
   shim.wrapReturn(mysql, "createPool", wrapCreatePool);
   function wrapCreatePool(shim, fn, fnName, pool) {
+    if (shim[symbols.unwrapPool]) {
+      return
+    }
+
     if (wrapQueryable(shim, pool, true) && wrapGetConnection(shim, pool)) {
-      shim.unwrap(mysql, "createPool");
+      shim[symbols.unwrapPool] = true
     }
   }
 
   shim.wrapReturn(mysql, "createPoolCluster", wrapCreatePoolCluster);
   function wrapCreatePoolCluster(shim, fn, fnName, poolCluster) {
+    if (shim[symbols.createPoolCluster]) {
+      return
+    }
+
     const proto = Object.getPrototypeOf(poolCluster);
     shim.wrapReturn(proto, "of", wrapPoolClusterOf);
     function wrapPoolClusterOf(shim, of, _n, poolNamespace) {
-      if (wrapGetConnection(shim, poolNamespace)) {
-        shim.unwrap(proto, "of");
+      if (poolNamespace[symbols.clusterOf]) {
+        return
       }
+
+      if (wrapGetConnection(shim, poolNamespace) && wrapQueryable(shim, poolNamespace, false)) {
+        poolNamespace[symbols.clusterOf] = true
+      }
+
     }
     if (wrapGetConnection(shim, poolCluster)) {
-      shim.unwrap(mysql, "createPoolCluster");
+      shim[symbols.createPoolCluster] = true
     }
   }
 }
@@ -101,9 +124,12 @@ function wrapGetConnection(shim, connectable) {
       const args = shim.toArray(arguments);
       const cbIdx = args.length - 1;
 
-      if (shim.isFunction(args[cbIdx]) && !shim.isWrapped(args[cbIdx])) {
+      // avoid an infinite loop and check both the cb and the "original" cb before re-wrapping
+      // this is only applicable now with the security agent + us doing the same thing
+      const original = shim.getOriginalOnce(args[cbIdx])
+      if (shim.isFunction(args[cbIdx]) && !(shim.isWrapped(args[cbIdx]) || shim.isWrapped(original))) {
         let cb = args[cbIdx];
-        if (!shim.__wrappedPoolConnection) {
+        if (!shim[symbols.wrappedPoolConnection]) {
           cb = shim.wrap(cb, wrapGetConnectionCallback);
         }
         args[cbIdx] = shim.bindSegment(cb);
@@ -121,7 +147,7 @@ function wrapGetConnectionCallback(shim, cb) {
       if (!err && wrapQueryable(shim, conn, false)) {
         // Leave getConnection wrapped in order to maintain TX state, but we can
         // simplify the wrapping of its callback in future calls.
-        shim.__wrappedPoolConnection = true;
+        shim[symbols.wrappedPoolConnection] = true
       }
     } catch (_err) { }
     return cb.apply(this, arguments);


### PR DESCRIPTION
I rebased the `k2-release` branch in agent which contained some mysql instrumentation fixes.  That uncovered the fact that both the agent and security agent instrumentation does not play nicely.  This PR fixes a few things:
 * removes `shim.unwrap` as it no longer functions since you started using agent.
 * replaces `shim.unwrap` with assigning symbols and checking those on whether or not to run instrumentation
 * Makes the fix that causes this [error](https://github.com/newrelic/node-newrelic/actions/runs/5190976801/jobs/9358178905)