### PR TITLE
perf: Fixed batch size threshold to 40

### DIFF
--- a/lib/nr-security-agent/lib/core/connections/websocket/response/IASTUtils.js
+++ b/lib/nr-security-agent/lib/core/connections/websocket/response/IASTUtils.js
@@ -6,7 +6,7 @@ const { Agent } = require('../../../agent');
 let completedRequestIds = new Set();
 const PolicyManager = require('../../../Policy');
 let batchSize;
-const batchthreshold = 300;
+const batchthreshold = 40;
 function getCompletedRequestIds() {
     return [...completedRequestIds];
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Set upper limit on IAST batch size to 40 to limit memory usage while IAST scan

