### PR TITLE
fix: Disable instrumentation when security enabled flag is set to false

### DIFF
--- a/lib/nr-security-agent/index.js
+++ b/lib/nr-security-agent/index.js
@@ -159,6 +159,10 @@ function getProcCMDLineSanitized(applicationInfoModule) {
 }
 
 (() => {
+    if(!NRAgent.config.security.enabled){
+        logger.warn("security.enabled flag is set to false");
+        return;
+    }
     if (initialize()) {
         require('../instrumentation-security');
         initLogger.info("[STEP-6] => Application instrumentation applied successfully");


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

When security.enabled flag is set to false. Do not apply instrumentation on modules.

## How to Test

Run application with security.enabled flag to false. 

## Related Issues

Fixes [NR-150058](https://issues.newrelic.com/browse/NR-150058)