### PR TITLE
chore: Upgrade axios to 1.6.0 to resolve CVE-2023-45857

### DIFF
--- a/lib/nr-security-agent/lib/core/connections/websocket/response/fuzz-request-handler.js
+++ b/lib/nr-security-agent/lib/core/connections/websocket/response/fuzz-request-handler.js
@@ -180,7 +180,10 @@ function handleFuzzResponse(response, fuzzDetails) {
  */
 function parseAxiosHttpRequestToFuzz(requestObject) {
     let serverName = requestObject.serverName ? requestObject.serverName : LOCALHOST;
-    let host = serverName + COLON + requestObject.serverPort
+    let host = serverName + COLON + requestObject.serverPort;
+    if(requestObject.headers && requestObject.headers['content-length']){
+        delete requestObject.headers['content-length'];
+    }
     return {
         url: requestObject.protocol + COLON_SLASH_SLASH + host + requestObject.url,
         method: requestObject.method,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5472,11 +5472,25 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -9297,6 +9311,11 @@
           "dev": true
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.405.0",
-    "axios": "0.21.4",
+    "axios": "1.6.0",
     "check-disk-space": "3.3.1",
     "content-type": "^1.0.5",
     "fast-safe-stringify": "^2.1.1",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

1. Upgraded axios to 1.6.0 to resolve CVE-2023-45857.
2. Upgrade to latest version introduced regression in IAST fuzzing. Fixed the same by removing content-length header.


## Related Issues

Fixes: [NR-174174](https://new-relic.atlassian.net/browse/NR-174174)