### PR TITLE
feat: Functionality to truncate Incoming HTTP request upto default limit

### DIFF
--- a/lib/instrumentation-security/core/request-manager.js
+++ b/lib/instrumentation-security/core/request-manager.js
@@ -48,13 +48,14 @@ function getRequest(shim) {
  * @param {*} shim 
  * @param {*} data 
  */
-function updateRequestBody(shim, data) {
+function updateRequestBody(shim, data, isTruncated) {
     const segment = shim.getActiveSegment();
     if (segment) {
         const transactionId = segment.transaction.id;
         const requestData = getRequestFromId(transactionId);
         if (requestData) {
             requestData.body = data;
+            requestData.dataTruncated = isTruncated;
             setRequest(transactionId, requestData);
         }
     }
@@ -65,6 +66,7 @@ function updateRequestBody(shim, data) {
             const requestData = getRequestFromId(traceId);
             if (requestData) {
                 requestData.body = data;
+                requestData.dataTruncated = isTruncated;
                 setRequest(traceId, requestData)
             }
         }

--- a/lib/instrumentation-security/core/sec-utils.js
+++ b/lib/instrumentation-security/core/sec-utils.js
@@ -191,6 +191,7 @@ function addRequestData(shim, request) {
           });
         }
         data.clientIP = requestIp.getClientIp(request);
+        data.dataTruncated = false;
         const transactionId = segment.transaction.id;
         const storedRequest = requestManager.getRequestFromId(transactionId);
         if (storedRequest && storedRequest.uri) {

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -227,6 +227,7 @@ function addRequestData(shim, request) {
         });
       }
       data.clientIP = requestIp.getClientIp(request);
+      data.dataTruncated = false;
       const transactionId = segment.transaction.id;
       const storedRequest = requestManager.getRequestFromId(transactionId);
       if (storedRequest && storedRequest.uri) {

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -39,6 +39,8 @@ const CSEC_HOME_TMP_CONST = new RegExp(find, 'g');
 let CSEC_HOME = NRAgent && NRAgent.config.newrelic_home ? NRAgent.config.newrelic_home : NRAgent && NRAgent.config.logging.filepath ? path.dirname(NRAgent.config.logging.filepath) : require('path').join(process.cwd());
 const CSEC_HOME_TMP = `${CSEC_HOME}/nr-security-home/tmp/language-agent/${process.env.applicationUUID}`
 
+const requestBodyLimit = 300;
+
 /**
  * Entry point of http module hook
  * @param {*} shim 
@@ -326,7 +328,23 @@ function onDataHook(shim, mod) {
         const requestData = requestManager.getRequestFromId(transactionId);
         if (requestData) {
           data = requestData.body ? requestData.body.concat(chunk.toString()) : chunk.toString();
-          requestManager.updateRequestBody(shim, data);
+          requestManager.updateRequestBody(shim, data, false);
+          
+          try {
+            const contentLength = requestData.headers['content-length'];
+            let bodyLimit = NRAgent.config.security.request && NRAgent.config.security.request.body_limit ? NRAgent.config.security.request.body_limit : requestBodyLimit;
+            if (!isNaN(bodyLimit)) {
+              bodyLimit = bodyLimit * 1000;
+              if (contentLength && contentLength > bodyLimit) {
+                data = truncateStringToBytes(data, bodyLimit);
+                requestManager.updateRequestBody(shim, data, true);
+              }
+            }
+            
+          } catch (error) {
+            logger.error("Error while truncating request body", error);
+          }
+
         }
 
       }
@@ -462,4 +480,18 @@ function deleteTempFileForIAST(file) {
   } catch (error) {
     logger.debug("Unable to delete temporary file", error);
   }
+}
+
+
+function truncateStringToBytes(inputString, maxBytes) {
+  if (!inputString || maxBytes <= 0) {
+    return EMPTY_STRING; // Return an empty string if input is invalid
+  }
+  const buffer = Buffer.from(inputString, UTF8);
+  if (buffer.length <= maxBytes) {
+    return inputString;
+  }
+  const truncatedBuffer = buffer.slice(0, maxBytes);
+  const truncatedString = truncatedBuffer.toString(UTF8);
+  return truncatedString;
 }

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -40,7 +40,7 @@ let CSEC_HOME = NRAgent && NRAgent.config.newrelic_home ? NRAgent.config.newreli
 const CSEC_HOME_TMP = `${CSEC_HOME}/nr-security-home/tmp/language-agent/${process.env.applicationUUID}`
 let lastTransactionId = EMPTY_STRING;
 let uncaughtExceptionReportFlag = false;
-const requestBodyLimit = 300;
+const requestBodyLimit = 500;
 
 
 /**

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -258,6 +258,9 @@ function addRequestData(shim, request) {
  */
 function emitHook(shim, mod, moduleName) {
   shim.wrap(mod && mod.Server && mod.Server.prototype, 'emit', function makeEmitWrapper(shim, fn) {
+    if (!shim.isFunction(fn)) {
+      return fn
+    }
     return function emitWrapper() {
       const req = arguments[1];
       const resp = arguments[2];
@@ -268,6 +271,9 @@ function emitHook(shim, mod, moduleName) {
         }
 
         shim.wrap(req, 'on', function makeOnWrapper(shim, fn) {
+          if (!shim.isFunction(fn)) {
+            return fn
+          }
           return function OnWrapper() {
             if (!requestManager.getRequest(shim)) {
               addRequestData(shim, req);
@@ -297,6 +303,9 @@ function emitHook(shim, mod, moduleName) {
  */
 function createServerHook(shim, mod) {
   shim.wrap(mod, 'createServer', function createServerWrapper(shim, fn) {
+    if (!shim.isFunction(fn)) {
+      return fn
+    }
     return function wrappedCreateServer() {
       shim.wrap(arguments, '0', function appWrapper(shim, fn) {
         return function wrappedApp() {
@@ -319,6 +328,9 @@ function createServerHook(shim, mod) {
  */
 function onDataHook(shim, mod) {
   shim.wrap(mod, '1', function makeOnDataWrapper(shim, fn) {
+    if (!shim.isFunction(fn)) {
+      return fn
+    }
     return function onDataWrapper() {
       const chunk = arguments[0];
       const chunkType = typeof chunk;
@@ -366,6 +378,9 @@ function responseHook(resp, req, shim) {
   resp.res.body = EMPTY_STRING;
 
   shim.wrap(resp, 'write', function makeWriteWrapper(shim, fn) {
+    if (!shim.isFunction(fn)) {
+      return fn
+    }
     return function wrappedWrite() {
       const response = this;
       responseBodyCompute(response, arguments);
@@ -374,6 +389,9 @@ function responseHook(resp, req, shim) {
   })
   // wrapper for response.end() 
   shim.wrap(resp, 'end', function makeEndWrapper(shim, fn) {
+    if (!shim.isFunction(fn)) {
+      return fn
+    }
     return function wrappedEnd() {
       const response = this;
       responseBodyCompute(response, arguments);

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -40,6 +40,7 @@ let CSEC_HOME = NRAgent && NRAgent.config.newrelic_home ? NRAgent.config.newreli
 const CSEC_HOME_TMP = `${CSEC_HOME}/nr-security-home/tmp/language-agent/${process.env.applicationUUID}`
 let lastTransactionId = EMPTY_STRING;
 let uncaughtExceptionReportFlag = false;
+const requestBodyLimit = 300;
 
 
 /**
@@ -244,6 +245,7 @@ function addRequestData(shim, request) {
         });
       }
       data.clientIP = requestIp.getClientIp(request);
+      data.dataTruncated = false;
       const transactionId = segment.transaction.id;
       const storedRequest = requestManager.getRequestFromId(transactionId);
       lastTransactionId = transactionId;
@@ -363,7 +365,21 @@ function onDataHook(shim, mod) {
         const requestData = requestManager.getRequestFromId(transactionId);
         if (requestData) {
           data = requestData.body ? requestData.body.concat(chunk.toString()) : chunk.toString();
-          requestManager.updateRequestBody(shim, data);
+          requestManager.updateRequestBody(shim, data, false);
+          try {
+            const contentLength = requestData.headers['content-length'];
+            let bodyLimit = requestBodyLimit;
+            if (!isNaN(bodyLimit)) {
+              bodyLimit = bodyLimit * 1000;
+              if (contentLength && contentLength > bodyLimit) {
+                data = truncateStringToBytes(data, bodyLimit);
+                requestManager.updateRequestBody(shim, data, true);
+              }
+            }
+
+          } catch (error) {
+            logger.error("Error while truncating request body", error);
+          }
         }
 
       }
@@ -594,7 +610,7 @@ function deleteTempFileForIAST(file) {
  */
 process.on('uncaughtException', (err, origin) => {
   console.error(err);
-  if(uncaughtExceptionReportFlag){
+  if (uncaughtExceptionReportFlag) {
     process.exit(1);
   }
   const request = requestManager.getRequestFromId(lastTransactionId);
@@ -605,3 +621,16 @@ process.on('uncaughtException', (err, origin) => {
   logger.error("An uncaughtException is detected:", err);
   uncaughtExceptionReportFlag = true;
 });
+
+function truncateStringToBytes(inputString, maxBytes) {
+  if (!inputString || maxBytes <= 0) {
+    return EMPTY_STRING; // Return an empty string if input is invalid
+  }
+  const buffer = Buffer.from(inputString, UTF8);
+  if (buffer.length <= maxBytes) {
+    return inputString;
+  }
+  const truncatedBuffer = buffer.slice(0, maxBytes);
+  const truncatedString = truncatedBuffer.toString(UTF8);
+  return truncatedString;
+}

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -367,7 +367,7 @@ function onDataHook(shim, mod) {
           data = requestData.body ? requestData.body.concat(chunk.toString()) : chunk.toString();
           requestManager.updateRequestBody(shim, data, false);
           try {
-            const contentLength = requestData.headers['content-length'];
+            const contentLength = Buffer.byteLength(data, 'utf8');
             let bodyLimit = requestBodyLimit;
             if (!isNaN(bodyLimit)) {
               bodyLimit = bodyLimit * 1000;


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

* Implemented logic to truncate incoming http request for IAST processing.
* Added dataTruncated flag in event JSON.
* Default limit is 500KB



## Related Issues
Fixes [NR-173806](https://new-relic.atlassian.net/issues/NR-173806)

[NR-173806]: https://new-relic.atlassian.net/browse/NR-173806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ