### PR TITLE
chore: Updated instrumented to get the transaction directly instead of from the active segment

### DIFF
--- a/lib/instrumentation-security/core/request-manager.js
+++ b/lib/instrumentation-security/core/request-manager.js
@@ -29,9 +29,9 @@ function setRequest(id, requestData) {
  * @returns 
  */
 function getRequest(shim) {
-    const segment = shim.getActiveSegment();
-    if (segment) {
-        const transactionId = segment.transaction.id;
+    const transaction = shim.tracer.getTransaction();
+    if (transaction) {
+        const transactionId = transaction.id;
         return getRequestFromId(transactionId);
     }
     else if (shim.agent.getLinkingMetadata()) {
@@ -49,9 +49,9 @@ function getRequest(shim) {
  * @param {*} data 
  */
 function updateRequestBody(shim, data, isTruncated) {
-    const segment = shim.getActiveSegment();
-    if (segment) {
-        const transactionId = segment.transaction.id;
+    const transaction = shim.tracer.getTransaction(); 
+    if (transaction) {
+        const transactionId = transaction.id;
         const requestData = getRequestFromId(transactionId);
         if (requestData) {
             requestData.body = data;

--- a/lib/instrumentation-security/core/sec-utils.js
+++ b/lib/instrumentation-security/core/sec-utils.js
@@ -172,15 +172,15 @@ function createPathIfNotExist(dir) {
 function addRequestData(shim, request) {
     try {
         const data = Object.assign({});
-        const segment = shim.getActiveSegment();
-        if (segment && segment.transaction) {
+        const transaction = shim.tracer.getTransaction();
+        if (transaction) {
             data.protocol = (request.connection && request.connection.encrypted) ? 'https' : 'http';
             data.body = null;
             data.headers = request.headers;
             data.url = request.url;
             data.method = request.method;
             data.httpVersion = request.httpVersion;
-            data.serverPort = segment.transaction.port;
+            data.serverPort = transaction.port;
             data.contextPath = '/';
             const queryObject = URL.parse(request.url, true).query;
             data.parameterMap = {};
@@ -195,7 +195,7 @@ function addRequestData(shim, request) {
             }
             data.clientIP = requestIp.getClientIp(request);
             data.dataTruncated = false;
-            const transactionId = segment.transaction.id;
+            const transactionId = transaction.id;
             const storedRequest = requestManager.getRequestFromId(transactionId);
             if (storedRequest && storedRequest.uri) {
                 data.uri = storedRequest.uri;

--- a/lib/instrumentation-security/hooks/director/nr-director.js
+++ b/lib/instrumentation-security/hooks/director/nr-director.js
@@ -71,15 +71,15 @@ module.exports = function initialize(shim, director) {
  * @param {*} params 
  */
 function extractParams(shim, params) {
-  const segment = shim.getActiveSegment();
-  if (segment && segment.transaction) {
-    let request = requestManager.getRequestFromId(segment.transaction.id);
+  const transaction = shim.tracer.getTransaction(); 
+  if (transaction) {
+    let request = requestManager.getRequestFromId(transaction.id);
     if (params && request) {
       Object.keys(params).forEach(function (key) {
         if (params[key]) {
           if (!request.parameterMap[key]) {
             request.parameterMap[key] = new Array(params[key].toString());
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
           }
         }
       });
@@ -91,7 +91,7 @@ function extractParams(shim, params) {
       if (uri.includes(param)) {
         uri = lodash.replace(uri, param, ':param_input');
         request.uri  = uri;
-        requestManager.setRequest(segment.transaction.id, request);
+        requestManager.setRequest(transaction.id, request);
       }
     }
   }

--- a/lib/instrumentation-security/hooks/express/nr-express.js
+++ b/lib/instrumentation-security/hooks/express/nr-express.js
@@ -82,15 +82,15 @@ function extractParams(shim, req) {
   if (!requestManager.getRequest(shim)) {
     secUtils.addRequestData(shim, req);
   }
-  const segment = shim.getActiveSegment();
-  if (segment && segment.transaction) {
-    let request = requestManager.getRequestFromId(segment.transaction.id);
+  const transaction = shim.tracer.getTransaction();
+  if (transaction) {
+    let request = requestManager.getRequestFromId(transaction.id);
     if (req.params && request) {
       Object.keys(req.params).forEach(function (key) {
         if (req.params[key]) {
           if (!request.parameterMap[key]) {
             request.parameterMap[key] = new Array(req.params[key].toString());
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
           }
         }
       });
@@ -100,14 +100,14 @@ function extractParams(shim, req) {
         if (req.query[key]) {
           if (!request.parameterMap[key]) {
             request.parameterMap[key] = new Array(req.query[key].toString());
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
           }
         }
       });
     }
     if (req.route && req.route.path && request) {
       request.uri = req.route.path;
-      requestManager.setRequest(segment.transaction.id, request);
+      requestManager.setRequest(transaction.id, request);
     }
   }
 }

--- a/lib/instrumentation-security/hooks/fastify/nr-fastify.js
+++ b/lib/instrumentation-security/hooks/fastify/nr-fastify.js
@@ -121,15 +121,15 @@ function extractParams(shim, req) {
   try {
     const reqURL = req.url || req.raw.url;
     const parsedURI = url.parse(reqURL).pathname;
-    const segment = shim.getActiveSegment();
-    if (segment && segment.transaction) {
-      let request = requestManager.getRequestFromId(segment.transaction.id);
+    const transaction = shim.tracer.getTransaction();
+    if (transaction) {
+      let request = requestManager.getRequestFromId(transaction.id);
       if (req.params && segment && request) {
         Object.keys(req.params).forEach(function (key) {
           if (req.params[key]) {
             if (!request.parameterMap[key]) {
               request.parameterMap[key] = new Array(req.params[key].toString());
-              requestManager.setRequest(segment.transaction.id, request);
+              requestManager.setRequest(transaction.id, request);
             }
           }
         });
@@ -139,7 +139,7 @@ function extractParams(shim, req) {
           if (req.query[key]) {
             if (!request.parameterMap[key]) {
               request.parameterMap[key] = new Array(req.query[key].toString());
-              requestManager.setRequest(segment.transaction.id, request);
+              requestManager.setRequest(transaction.id, request);
             }
           }
         });
@@ -147,7 +147,7 @@ function extractParams(shim, req) {
       let method = request.method.toUpperCase();
       if (parsedURI && request && requestManager.requestMap[method + ATTHERATE + parsedURI]) {
         request.uri = parsedURI;
-        requestManager.setRequest(segment.transaction.id, request);
+        requestManager.setRequest(transaction.id, request);
       }
     }
   } catch (error) {

--- a/lib/instrumentation-security/hooks/grpc-js/nr-grpc.js
+++ b/lib/instrumentation-security/hooks/grpc-js/nr-grpc.js
@@ -282,8 +282,8 @@ function wrapCallback(shim, mod, method) {
 function addRequestData(shim, type, path, args) {
   const data = Object.assign({});
   try {
-    const segment = shim.getActiveSegment();
-    if (segment && segment.transaction) {
+    const transaction = shim.tracer.getTransaction(); 
+    if (transaction) {
       data.method = path;
       data.url = path;
       data.uri = path;
@@ -298,7 +298,7 @@ function addRequestData(shim, type, path, args) {
       data.isGrpc = true;
       data.body = JSON.stringify(args.request);
       data.serverPort = shim.serverPort;
-      const transactionId = segment.transaction.id;
+      const transactionId = transaction.id;
       requestManager.setRequest(transactionId, data);
     }
   } catch (error) {

--- a/lib/instrumentation-security/hooks/hapi/nr-hapi.js
+++ b/lib/instrumentation-security/hooks/hapi/nr-hapi.js
@@ -101,15 +101,15 @@ function handlerWrapper(shim, mod) {
  * @param {*} req 
  */
 function extractParams(shim, req) {
-  const segment = shim.getActiveSegment();
-  if (segment && segment.transaction) {
-    let request = requestManager.getRequestFromId(segment.transaction.id);
+  const transaction = shim.tracer.getTransaction();
+  if (transaction) {
+    let request = requestManager.getRequestFromId(transaction.id);
     if (req.params && request) {
       Object.keys(req.params).forEach(function (key) {
         if (req.params[key]) {
           if (!request.parameterMap[key]) {
             request.parameterMap[key] = new Array(req.params[key].toString());
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
           }
         }
       });
@@ -119,14 +119,14 @@ function extractParams(shim, req) {
         if (req.query[key]) {
           if (!request.parameterMap[key]) {
             request.parameterMap[key] = new Array(req.query[key].toString());
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
           }
         }
       });
     }
     if (req.route && req.route.path && request) {
       request.uri = req.route.path;
-      requestManager.setRequest(segment.transaction.id, request);
+      requestManager.setRequest(transaction.id, request);
     }
   }
 }

--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -229,15 +229,15 @@ function parseFuzzheaders(requestData, transactionId) {
 function addRequestData(shim, request) {
   try {
     const data = Object.assign({});
-    const segment = shim.getActiveSegment();
-    if (segment && segment.transaction) {
+    const transaction = shim.tracer.getTransaction(); 
+    if (transaction) {
       data.protocol = (request.connection && request.connection.encrypted) ? 'https' : 'http';
       data.body = null;
       data.headers = request.headers;
       data.url = request.url;
       data.method = request.method;
       data.httpVersion = request.httpVersion;
-      data.serverPort = segment.transaction.port;
+      data.serverPort = transaction.port;
       data.contextPath = '/';
       const queryObject = URL.parse(request.url, true).query;
       data.parameterMap = {};
@@ -252,7 +252,7 @@ function addRequestData(shim, request) {
       }
       data.clientIP = requestIp.getClientIp(request);
       data.dataTruncated = false;
-      const transactionId = segment.transaction.id;
+      const transactionId = transaction.id;
       const storedRequest = requestManager.getRequestFromId(transactionId);
       lastTransactionId = transactionId;
       if (storedRequest && storedRequest.uri) {
@@ -364,10 +364,10 @@ function onDataHook(shim, mod) {
     return function onDataWrapper() {
       const chunk = arguments[0];
       const chunkType = typeof chunk;
-      segment = shim.getActiveSegment()
+      const transaction = shim.tracer.getTransaction();
       if (chunkType === STRING_TYPE || chunkType === ARRAY_TYPE || chunkType === BUFFER_TYPE || chunkType === UINT8ARRAY_TYPE || chunkType === OBJECT_TYPE) {
         let data = chunk.toString();
-        const transactionId = segment.transaction.id;
+        const transactionId = transaction.id;
         const requestData = requestManager.getRequestFromId(transactionId);
         if (requestData) {
           data = requestData.body ? requestData.body.concat(chunk.toString()) : chunk.toString();

--- a/lib/instrumentation-security/hooks/koa/@koa/nr-@koa-router.js
+++ b/lib/instrumentation-security/hooks/koa/@koa/nr-@koa-router.js
@@ -62,14 +62,14 @@ function paramHook(shim, mod, moduleName) {
     shim.wrap(mod && mod.prototype, 'params', function wrapMatch(shim, fn) {
         logger.debug(`Instrumenting ${moduleName}.prototype.params`);
         return function wrappedMatch() {
-            const segment = shim.getActiveSegment();
-            if (segment && segment.transaction) {
-                let request = requestManager.getRequestFromId(segment.transaction.id);
+            const transaction = shim.tracer.getTransaction();
+            if (transaction) {
+                let request = requestManager.getRequestFromId(transaction.id);
                 try {
                     const uri = this.path;
                     if (request) {
                         request.uri = uri;
-                        requestManager.setRequest(segment.transaction.id, request);
+                        requestManager.setRequest(transaction.id, request);
                     }
 
                 } catch (error) {
@@ -97,7 +97,7 @@ function paramHook(shim, mod, moduleName) {
                             }
                         });
                     }
-                    requestManager.setRequest(segment.transaction.id, request);
+                    requestManager.setRequest(transaction.id, request);
                 } catch (error) {
 
                 }

--- a/lib/instrumentation-security/hooks/restify/nr-restify.js
+++ b/lib/instrumentation-security/hooks/restify/nr-restify.js
@@ -66,17 +66,17 @@ function initialize(shim, mod, moduleName) {
  * @param {*} req 
  */
 function extractParams(shim, req) {
-    const segment = shim.getActiveSegment();
-    if (segment && segment.transaction) {
+    const transaction = shim.tracer.getTransaction(); 
+    if (transaction) {
 
-        let request = requestManager.getRequestFromId(segment.transaction.id);
+        let request = requestManager.getRequestFromId(transaction.id);
         if (req.params && request) {
             try {
                 Object.keys(req.params).forEach(function (key) {
                     if (req.params[key]) {
                         if (!request.parameterMap[key]) {
                             request.parameterMap[key] = new Array(req.params[key].toString());
-                            requestManager.setRequest(segment.transaction.id, request);
+                            requestManager.setRequest(transaction.id, request);
                         }
                     }
                 });
@@ -91,7 +91,7 @@ function extractParams(shim, req) {
                 Object.keys(query).forEach(function (key) {
                     if (query[key]) {
                         request.parameterMap[key] = new Array(query[key].toString());
-                        requestManager.setRequest(segment.transaction.id, request);
+                        requestManager.setRequest(transaction.id, request);
                     }
                 });
             } catch (error) {
@@ -100,7 +100,7 @@ function extractParams(shim, req) {
         }
         if (req.route && req.route.path && request) {
             request.uri = req.route.path;
-            requestManager.setRequest(segment.transaction.id, request);
+            requestManager.setRequest(transaction.id, request);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We are doing work to remove the transaction from segment. I happen to find this when I was testing something else out.  This PR removes getting the transaction
from the segment and instead gets the transaction from the context manager by way of the tracer.

## How to Test

I didn't update any tests because they don't seem to be relevant but I'm more than happy to add any tests you see fit.

## Related Issues
This PR should work now with any released agent but if this does not land before we release https://github.com/newrelic/node-newrelic/pull/2646 it will break the security agent.
