### PR TITLE
fix: Only listen once for uncaughtException

### DIFF
--- a/lib/instrumentation-security/hooks/http/nr-http.js
+++ b/lib/instrumentation-security/hooks/http/nr-http.js
@@ -629,7 +629,12 @@ function deleteTempFileForIAST(file) {
 /**
  * Collect and report the uncaught Exception
  */
-process.on('uncaughtException', (err, origin) => {
+const listeners = process.listeners('uncaughtException')
+if (listeners.findIndex(uncaughtListener) === -1) {
+  process.on('uncaughtException', uncaughtListener);
+}
+
+function uncaughtListener(err, origin) {
   console.error(err);
   if (uncaughtExceptionReportFlag) {
     process.exit(1);
@@ -641,7 +646,7 @@ process.on('uncaughtException', (err, origin) => {
   }
   logger.error("An uncaughtException is detected:", err);
   uncaughtExceptionReportFlag = true;
-});
+}
 
 /**
  * utility to parse response headers for cookie check


### PR DESCRIPTION
This PR fixes an issue where the security agent adds the same listener many times which can result in a too many listeners error.